### PR TITLE
Set randomname use a GUID instead.

### DIFF
--- a/src/MainModule/Packages/System.Core/Server/Modules/Remote.lua
+++ b/src/MainModule/Packages/System.Core/Server/Modules/Remote.lua
@@ -681,7 +681,7 @@ return {
 		local objNameValue = Package.Shared.EventObjectName
 		local sharedKeyValue = Package.Shared.SharedKey
 
-		objNameValue.Value = Utilities:RandomString()
+		objNameValue.Value = cRoot.Services.HttpService:GenerateGUID(false)
 		sharedKeyValue.Value = Utilities:RandomString()
 
 		Remote.EventObjectsName = objNameValue.Value


### PR DESCRIPTION
Basically there is no reason not to use a GUID for a name