### PR TITLE
Made IDEs trim trailing whitespace and use linefeed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,11 @@
 [*.lua]
 indent_style = tab
 indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
 
 [*.json]
 indent_style = tab
 indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,13 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Change line endings to LF
+*.lua text=auto
+*.lua eol=lf
+*.json text=auto
+*.json eol=lf
+*.rbxmx text=auto
+*.rbxmx eol=lf
+*.md text=auto
+*.md eol=lf
+*.toml text=auto
+*.toml eol=lf
+*.yml text=auto
+*.yml eol=lf


### PR DESCRIPTION
This makes the Github IDE (and other IDEs):

- Trim trailing whitespace (Roblox studio already does this)
- Use linefeed as the line terminator (in case some other IDEs use something else). Fixes incompatibilities with some IDEs